### PR TITLE
Fix save detection for Kristal mods

### DIFF
--- a/scripts/main/utils_general.lua
+++ b/scripts/main/utils_general.lua
@@ -119,7 +119,8 @@ function Mod:hasSaveFiles(id, specific_file, fused_identify)
     local paths = {
         "LOVE/kristal/saves/",                      -- Source code version
         "kristal/saves/",                           -- Executable version
-        (fused_identify or id).."/saves/",  -- Executable version but changed Kristal's id in conf.lua
+        "LOVE/"..(fused_identify or id).."/saves/", -- Source code version but changed Kristal's id in conf.lua
+        (fused_identify or id).."/saves/",  		-- Executable version but changed Kristal's id in conf.lua
     }
 
     for i,v in ipairs(paths) do

--- a/scripts/world/cutscenes/pc.lua
+++ b/scripts/world/cutscenes/pc.lua
@@ -39,7 +39,7 @@ return function(cutscene, event, chara)
 									table.insert(new_gifts, game)
 								end
 							else
-								if Mod:hasSaveFiles(game:sub(start+1), nil, data.fused_identify) then
+								if Mod:hasSaveFiles(game:sub(start+1), data.file or nil, data.fused_identify) then
 									table.insert(new_gifts, game)
 								end
 							end


### PR DESCRIPTION
1. We never added the source code version for a changed Kristal identity.
2. Added detection for Kristal save files other than file_0 through file_3.