### PR TITLE
Un-Harcode your key binds

### DIFF
--- a/libraries/TauntSoul/scripts/objects/TauntSoul.lua
+++ b/libraries/TauntSoul/scripts/objects/TauntSoul.lua
@@ -73,7 +73,7 @@ function TauntSoul:update()
     self.parried_loop_sfx:setVolume(Utils.clampMap(self.parry_inv, 0, self.parry_length / 2, 0, 1))
     --]]
 
-    if Input.pressed("v", false) and self:canParry() then
+    if Input.pressed("taunt", false) and self:canParry() then
         Game.lock_movement = true
 
         self:flash()

--- a/scripts/data/items/armors/focus.lua
+++ b/scripts/data/items/armors/focus.lua
@@ -59,12 +59,7 @@ end
 
 -- Function overrides go here
 function item:getDescription() 
-    print(self.id)
-    if self.id == "focus" then
-        return "Hold [color:yellow][" .. string.upper(Input.key_bindings["focus_placebo"][1]) .. "][color:reset] during battle to slow down time.\nTP bar determines amount of time you can use it."
-    else
-        return self.description
-    end
+    return "Hold [color:yellow][" .. string.upper(Input.key_bindings["focus_placebo"][1]) .. "][color:reset] during battle to slow down time.\nTP bar determines amount of time you can use it."
 end
 
 return item

--- a/scripts/data/items/armors/focus.lua
+++ b/scripts/data/items/armors/focus.lua
@@ -18,7 +18,7 @@ function item:init()
     -- Shop description
     self.shop = ""
     -- Menu description
-    self.description = "Hold [color:yellow]" .. "[F]" .. "[color:reset] during battle to slow down time.\nTP bar determines amount of time you can use it."
+    self.description = "Hold [color:yellow][F][color:reset] during battle to slow down time.\nTP bar determines amount of time you can use it."
 
     -- Default shop price (sell price is halved)
     self.price = 0
@@ -58,5 +58,13 @@ function item:init()
 end
 
 -- Function overrides go here
+function item:getDescription() 
+    print(self.id)
+    if self.id == "focus" then
+        return "Hold [color:yellow][" .. string.upper(Input.key_bindings["focus_placebo"][1]) .. "][color:reset] during battle to slow down time.\nTP bar determines amount of time you can use it."
+    else
+        return self.description
+    end
+end
 
 return item

--- a/scripts/globals/Gangnam.lua
+++ b/scripts/globals/Gangnam.lua
@@ -43,7 +43,7 @@ function Gangnam:update()
 	end
 
 	if self.is_gangnaming then
-		if not Input.down("a") or (Game.state ~= "OVERWORLD" or Game.world:hasCutscene()) then
+		if not Input.down("gangnam") or (Game.state ~= "OVERWORLD" or Game.world:hasCutscene()) then
 			local kris = Game.world:getCharacter("kris_lw")
 			self.is_gangnaming = false
 			kris:resetSprite()

--- a/scripts/globals/Speen.lua
+++ b/scripts/globals/Speen.lua
@@ -112,7 +112,7 @@ function Speen:update()
 			self:nextFacing()
 		end
 
-		if not Input.down("s") or (Game.state ~= "OVERWORLD" or Game.world:hasCutscene()) then
+		if not Input.down("speen") or (Game.state ~= "OVERWORLD" or Game.world:hasCutscene()) then
 			self.is_spinning = false
 			if self.lancered then
 				self.lancered = false

--- a/scripts/hooks/Soul.lua
+++ b/scripts/hooks/Soul.lua
@@ -241,7 +241,7 @@ function Soul:update()
     end
 
     -- Soul VFX
-    if not self.transitioning and Input.down("f") and Game:getTension() > 0 then
+    if not self.transitioning and Input.down("focus_placebo") and Game:getTension() > 0 then
     self.outline.alpha = Utils.approach(self.outline.alpha, 1, DTMULT / 4)
     self.concentratebg.alpha_fx.alpha = 1
     if self.afterimage_delay >= 5 then
@@ -275,7 +275,7 @@ function Soul:remove()
     self.outlinefx.active = false
     self.concentratebg:remove()
     if self.timeslow_sfx then self.timeslow_sfx:stop() end
-    Input.clear("f")
+    Input.clear("focus_placebo")
     super.remove(self)
 end
 

--- a/scripts/hooks/Soul.lua
+++ b/scripts/hooks/Soul.lua
@@ -236,7 +236,7 @@ function Soul:update()
     end
 
     -- Error sound if trying to use slowdown when out of TP
-    if Input.pressed("f") and Game:getTension() <= 0 then
+    if Input.pressed("focus_placebo") and Game:getTension() <= 0 then
         Assets.playSound("ui_cant_select", 2)
     end
 
@@ -406,7 +406,7 @@ function Soul:transitionTo(x, y, should_destroy) -- Fixes the focus visual effec
         self.concentratebg:remove()
         self.timeslow_sfx:stop()
     end
-	Input.clear("f")
+	Input.clear("focus_placebo")
 	super.transitionTo(self, x, y, should_destroy)
 end
 


### PR DESCRIPTION
Some key binds where sort of hard coded such as the speen, focus, gangnam style.
I also modified the focus item so that the desc change based of your key bind set for the focus button.
Also made the taunt button parry in battle, which shouldn't mess with anything.

Normally everything should work and I shouldn't have touching anything that I wasn't suppose too (in term of the modification that I was doing).