### PR TITLE
Changes to Intro cutscene + Hometown dialogues + jammed talkie walkie

### DIFF
--- a/mod.lua
+++ b/mod.lua
@@ -65,6 +65,10 @@ function Mod:init()
         "​"
     }
 
+    self.talkiewalkie_blacklist = {
+        "​",
+    }
+
     self.rpc_state = nil
 
     self:initTaunt()

--- a/scripts/world/cutscenes/hometown.lua
+++ b/scripts/world/cutscenes/hometown.lua
@@ -247,17 +247,34 @@ return {
         
         cutscene:text("* (It's a rusty fridge with some photos on it.)")
         local opinion = cutscene:choicer({"\nOpen\nFridge\n", "Don't", "See photos"})
-            if opinion == 1 then
-              cutscene:text("* (All that's inside is a jar with a single pickle in it...)")
-            elseif opinion == 3 then 
-              cutscene:text("* (A photo of your mother and father on their wedding day.)")
-              cutscene:text("* (She's holding a bouquet of seven flowers.)")
-              cutscene:text("* (A reindeer-looking monster stands nearby in a tuxedo.)")
-              cutscene:text("* (They all look happy.)")
+        if opinion == 1 then
+          cutscene:text("* (All that's inside is a jar with a single pickle in it...)")
+        elseif opinion == 3 then
+            local characters_who_knows_dreemurr = {
+                "susie",
+                "noelle",
+                "berdly",
+                "brenda",
+                "jamm",
+                "noel"
+            }
+            local leader_id = Mod:getLeader().id
+            if leader_id == "kris" then
+                cutscene:text("* (A photo of your mother and father on their wedding day.)")
+            elseif leader_id == "YOU" then
+                cutscene:text("* (A photo of Toriel and a random goat man on a wedding day.)")
+                cutscene:text("* (Wait... Toriel was married??)")
+            elseif Utils.containsValue(characters_who_knows_dreemurr, leader_id) then
+                cutscene:text("* (A photo of Toriel and Asgore on their wedding day.)")
             else
-              cutscene:text("* (You decide not to look.)")  
+                cutscene:text("* (A photo of two goat monsters on their wedding day.)")
             end
-
+          cutscene:text("* (She's holding a bouquet of seven flowers.)")
+          cutscene:text("* (A reindeer-looking monster stands nearby in a tuxedo.)")
+          cutscene:text("* (They all look happy.)")
+        else
+          cutscene:text("* (You decide not to look.)")  
+        end
     end,
 
     librarybook1 = function(cutscene, event)
@@ -269,8 +286,13 @@ return {
           cutscene:text("* (According to the card in the back...)")
           cutscene:text("* (... looks like your mother took it repeatedly many years ago.)")
         else
-          cutscene:text("* (There are photos of unfamiliar humans inside.)")
-          cutscene:text("* (You shut the book quickly.)")
+            cutscene:text("* (There are photos of unfamiliar humans inside.)")
+            local leader_id = Mod:getLeader().id
+            if leader_id == "kris" then
+                cutscene:text("* (You shut the book quickly.)")
+            elseif leader_id == "YOU" then
+                cutscene:text("* (Unfortunately, there's no photos of frogs like you.)")
+            end
         end
 
     end,
@@ -284,8 +306,6 @@ return {
           cutscene:text("* The font of our compassion. The source of our will.")
           cutscene:text("* The container of our \"life force.\"")
           cutscene:text("* But even now,[wait:5] the true function of it is unknown.")
-        else
-          
         end
 
     end,
@@ -318,8 +338,6 @@ return {
           cutscene:text("* FLAMIN HOT CHEESE SODA")
           cutscene:text("* GAMER BLOOD ENERGY DRINK")
           cutscene:text("* Juice (Red Flavor)")
-        else
-
         end
 
     end,

--- a/scripts/world/cutscenes/jaru_walkie_talkie.lua
+++ b/scripts/world/cutscenes/jaru_walkie_talkie.lua
@@ -1,5 +1,13 @@
 return function(cutscene, event_override)
     cutscene:text("* You turn on the walkie talkie...")
+
+    for i,map_id in ipairs(Mod.talkiewalkie_blacklist) do
+        if Utils.startsWith(Game.world.map.id, map_id) then
+            cutscene:text("* But the signal is jammed here...")
+            cutscene:endCutscene()
+            return
+        end
+    end
 	
     local jaru_talked_first_time = Game:getFlag("jaruHasUsedWalkieTalkie", false)
 	local jaru_talked_in_devroom = Game:getFlag("jaruCommunicationTest", false)


### PR DESCRIPTION
- Skipping the main intro will still ask the player if they want to activate the post-snowgrave content if they have a file for it
- To skip the intro, you'll actually have to press C and D, instead of the menu key and D _(yeah I did this instead of making the text adapt to which key is the menu key)_
- Made some dialogues less "Kris-only" in Hometown
- Added a list of rooms in which JARU's talkie walkie will have its signal jammed, like in MB's room