### PR TITLE
Workaround MG breaking minifaces

### DIFF
--- a/libraries/magical-glass/lib.lua
+++ b/libraries/magical-glass/lib.lua
@@ -1470,6 +1470,7 @@ function lib:init()
         end, {instant = false})
     
         self.advance_callback = nil
+        self.minifaces = {}
     end)
 
     Utils.hook(Textbox, "advance", function(orig, self)


### PR DESCRIPTION
Prevents the game from crashing every time a textbox finishes.
Shoutouts to VSCode for not giving me any indication that I changed 6000 line endings